### PR TITLE
fix: coerce date on persist

### DIFF
--- a/src/create-server.test.ts
+++ b/src/create-server.test.ts
@@ -83,6 +83,7 @@ const createTestServers = (serverOverrides: Partial<ServerOptions>) => {
 						"Set-Cookie": new Bun.Cookie({
 							name: "test-cookie",
 							value: "test-value",
+							expires: new Date(),
 						}).serialize(),
 					},
 				}),

--- a/src/create-server.ts
+++ b/src/create-server.ts
@@ -41,7 +41,9 @@ const CookieInitSchema = z.object({
 	value: z.string(),
 	domain: z.string().exactOptional(),
 	path: z.string().exactOptional(),
-	expires: z.union([z.number(), z.string()]).exactOptional(),
+	expires: z
+		.union([z.date().transform((d) => d.toISOString()), z.number(), z.string()])
+		.exactOptional(),
 	secure: z.boolean().exactOptional(),
 	sameSite: z.enum(["strict", "lax", "none"]).exactOptional(),
 	httpOnly: z.boolean().exactOptional(),


### PR DESCRIPTION
#33 was too strict, toJSON() does indeed keep the date object